### PR TITLE
add GB timezone

### DIFF
--- a/O365/utils/windows_tz.py
+++ b/O365/utils/windows_tz.py
@@ -411,6 +411,7 @@ IANA_TO_WIN = {
     'Europe/Zaporozhye': 'FLE Standard Time',
     'Europe/Zurich': 'W. Europe Standard Time',
     'GMT': 'GMT Standard Time',
+    'GB': 'GMT Standard Time',
     'Indian/Antananarivo': 'E. Africa Standard Time',
     'Indian/Chagos': 'Central Asia Standard Time',
     'Indian/Christmas': 'SE Asia Standard Time',


### PR DESCRIPTION
'GB': 'GMT Standard Time'  found in https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones